### PR TITLE
Fixed a bash syntax error in imx6.sh. 

### DIFF
--- a/target/linux/imx6/base-files/lib/imx6.sh
+++ b/target/linux/imx6/base-files/lib/imx6.sh
@@ -55,7 +55,7 @@ imx6_board_detect() {
 		;;
 
 	"Gateworks Ventana i.MX6 DualLite/Solo GW5907" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5907") |\
+	"Gateworks Ventana i.MX6 Dual/Quad GW5907" |\
 	"Gateworks Ventana GW5901" |\
 	"Gateworks Ventana GW5902")
 		name="gw590x"


### PR DESCRIPTION
It included a spurious ')' in a case statement.  This prevents sysupgrade from working.